### PR TITLE
Small corrections in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,14 @@ import React from "react";
 import { useCountRows } from "@saltcorn/react-lib/hooks";
 
 export default function App({ viewName, query }) {
-  const { count, isLoading, error } = useCountRows("users");
+  const { count, isCounting, error } = useCountRows("users");
 
   return (
     <div>
       <h3>
         Row count for users:{" "}
-        {isLoading
-          ? "Loading..."
+        {isCounting
+          ? "Count..."
           : error
           ? "Error fetching data"
           : count}


### PR DESCRIPTION
Just noticed a small inaccuracy in the readme, [because the object keys are different](https://github.com/saltcorn/react-lib/blob/9b11acd05fbc243626a1e7bfe9bb2288fb6845cb/src/hooks.ts#L19), the "spinner" will not display